### PR TITLE
Single-row UI

### DIFF
--- a/renderer/components/MailList.tsx
+++ b/renderer/components/MailList.tsx
@@ -130,10 +130,10 @@ const MailList: React.FC<IProps> = ({ onAddToDo, inbox }) => {
                     _hover={{
                         bg: "#0e0e52",
                     }}
-                    disabled={!selected}
+                    isDisabled={!selected.length}
                     onClick={convertToTodos}
                 >
-                    Add Todo
+                    Add Todos
                 </Button>
             </Box>
             <Box
@@ -151,32 +151,12 @@ const MailList: React.FC<IProps> = ({ onAddToDo, inbox }) => {
                             {tempInbox.map((message, idx) => {
                                 const isSelected = selected.includes(message.id);
                                 return (
-                                    <>
-                                        <MailListItem
-                                            message={message}
-                                            isSelected={isSelected}
-                                            selected={selected}
-                                            handleSelect={handleSelect}
-                                        />
-                                        {message.id === selected[selected.length - 1] && (
-                                            <Tr w="100%" display="flex">
-                                                <Td display="flex" flex="1 1 auto">
-                                                    <Button
-                                                        size="xs"
-                                                        variant="ghost"
-                                                        bg="blue.500"
-                                                        _hover={{ background: "blue.600" }}
-                                                        onClick={convertToTodos}
-                                                    >
-                                                        Add ToDo
-                                                    </Button>
-                                                </Td>
-                                                <Td display="flex" flex="0 0 auto"></Td>
-                                                <Td display="flex" flex="0 0 auto"></Td>
-                                                <Td display="flex" flex="0 0 auto"></Td>
-                                            </Tr>
-                                        )}
-                                    </>
+                                    <MailListItem
+                                        message={message}
+                                        isSelected={isSelected}
+                                        selected={selected}
+                                        handleSelect={handleSelect}
+                                    />
                                 );
                             })}
                         </Tbody>

--- a/renderer/components/MailList.tsx
+++ b/renderer/components/MailList.tsx
@@ -88,53 +88,102 @@ const MailList: React.FC<IProps> = ({ onAddToDo, inbox }) => {
     };
 
     return (
-        <Box
-            display="flex"
-            flexBasis="60%"
-            flexGrow={1}
-            flexShrink={1}
-            w="100%"
-            h="100%"
-            overflowX="hidden"
-        >
-            <TableContainer display="flex" w="100%" overflowY="scroll" overflowX="hidden">
-                <Table size="sm" style={{ tableLayout: "fixed" }}>
-                    <Tbody display="block">
-                        {tempInbox.map((message, idx) => {
-                            const isSelected = selected.includes(message.id);
-                            return (
-                                <>
-                                    <MailListItem
-                                        message={message}
-                                        isSelected={isSelected}
-                                        selected={selected}
-                                        handleSelect={handleSelect}
-                                    />
-                                    {message.id === selected[selected.length - 1] && (
-                                        <Tr w="100%" display="flex">
-                                            <Td display="flex" flex="1 1 auto">
-                                                <Button
-                                                    size="xs"
-                                                    variant="ghost"
-                                                    bg="blue.500"
-                                                    _hover={{ background: "blue.600" }}
-                                                    onClick={convertToTodos}
-                                                >
-                                                    Add ToDo
-                                                </Button>
-                                            </Td>
-                                            <Td display="flex" flex="0 0 auto"></Td>
-                                            <Td display="flex" flex="0 0 auto"></Td>
-                                            <Td display="flex" flex="0 0 auto"></Td>
-                                        </Tr>
-                                    )}
-                                </>
-                            );
-                        })}
-                    </Tbody>
-                </Table>
-            </TableContainer>
-        </Box>
+        <>
+            <Box
+                bg="gray.700"
+                w="100%"
+                h="50px"
+                display="flex"
+                flexDirection="row"
+                fontSize="13px"
+                fontWeight="bold"
+                alignItems="center"
+                justifyContent="space-between"
+                color="white"
+                padding="0 10px"
+            >
+                <Box w="100%" display="flex" flexDirection="row">
+                    <i>Inbox</i>
+                    {tempInbox.length > 0 ? (
+                        <Box
+                            marginLeft="8px"
+                            fontWeight="bold"
+                            fontSize="12px"
+                            bg="red.500"
+                            display="block"
+                            h="20px"
+                            borderRadius={50}
+                            textAlign="center"
+                            verticalAlign="center"
+                            alignContent="center"
+                            justifyContent="center"
+                            minW="32px"
+                        >
+                            {tempInbox.length}
+                        </Box>
+                    ) : null}
+                </Box>
+
+                <Button
+                    variant="primary"
+                    fontSize="14px"
+                    _hover={{
+                        bg: "#0e0e52",
+                    }}
+                    disabled={!selected}
+                    onClick={convertToTodos}
+                >
+                    Add Todo
+                </Button>
+            </Box>
+            <Box
+                display="flex"
+                flexBasis="60%"
+                flexGrow={1}
+                flexShrink={1}
+                w="100%"
+                h="100%"
+                overflowX="hidden"
+            >
+                <TableContainer display="flex" w="100%" overflowY="scroll" overflowX="hidden">
+                    <Table size="sm" style={{ tableLayout: "fixed" }}>
+                        <Tbody display="block">
+                            {tempInbox.map((message, idx) => {
+                                const isSelected = selected.includes(message.id);
+                                return (
+                                    <>
+                                        <MailListItem
+                                            message={message}
+                                            isSelected={isSelected}
+                                            selected={selected}
+                                            handleSelect={handleSelect}
+                                        />
+                                        {message.id === selected[selected.length - 1] && (
+                                            <Tr w="100%" display="flex">
+                                                <Td display="flex" flex="1 1 auto">
+                                                    <Button
+                                                        size="xs"
+                                                        variant="ghost"
+                                                        bg="blue.500"
+                                                        _hover={{ background: "blue.600" }}
+                                                        onClick={convertToTodos}
+                                                    >
+                                                        Add ToDo
+                                                    </Button>
+                                                </Td>
+                                                <Td display="flex" flex="0 0 auto"></Td>
+                                                <Td display="flex" flex="0 0 auto"></Td>
+                                                <Td display="flex" flex="0 0 auto"></Td>
+                                            </Tr>
+                                        )}
+                                    </>
+                                );
+                            })}
+                        </Tbody>
+                    </Table>
+                </TableContainer>
+            </Box>
+        </>
     );
 };
 

--- a/renderer/components/TodoList.tsx
+++ b/renderer/components/TodoList.tsx
@@ -96,8 +96,9 @@ const TodoList: React.FC<IProps> = ({ todos, removeFromToDos }) => {
                 fontWeight="bold"
                 alignItems="center"
                 padding="0 10px"
+                color="white"
             >
-                <i>To Do's</i>
+                <i>Todo</i>
                 {localTodos.length > 0 ? (
                     <Box
                         marginLeft="8px"
@@ -161,8 +162,8 @@ const TodoList: React.FC<IProps> = ({ todos, removeFromToDos }) => {
                                                     isSelected
                                                         ? "blue.500"
                                                         : !message.isRead
-                                                        ? "gray.800"
-                                                        : "gray.900"
+                                                        ? "gray.400"
+                                                        : "gray.500"
                                                 }
                                                 style={{
                                                     fontWeight: !message.isRead ? "bold" : "normal",

--- a/renderer/components/TodoList.tsx
+++ b/renderer/components/TodoList.tsx
@@ -95,28 +95,42 @@ const TodoList: React.FC<IProps> = ({ todos, removeFromToDos }) => {
                 fontSize="13px"
                 fontWeight="bold"
                 alignItems="center"
+                justifyContent="space-between"
                 padding="0 10px"
                 color="white"
             >
-                <i>Todo</i>
-                {localTodos.length > 0 ? (
-                    <Box
-                        marginLeft="8px"
-                        fontWeight="bold"
-                        fontSize="12px"
-                        bg="red.500"
-                        display="block"
-                        w="22px"
-                        h="20px"
-                        borderRadius={50}
-                        textAlign="center"
-                        verticalAlign="center"
-                        alignContent="center"
-                        justifyContent="center"
-                    >
-                        {localTodos.length}
-                    </Box>
-                ) : null}
+                <Box w="100%" display="flex" flexDirection="row">
+                    <i>Todo</i>
+                    {localTodos.length > 0 ? (
+                        <Box
+                            marginLeft="8px"
+                            fontWeight="bold"
+                            fontSize="12px"
+                            bg="red.500"
+                            display="block"
+                            w="22px"
+                            h="20px"
+                            borderRadius={50}
+                            textAlign="center"
+                            verticalAlign="center"
+                            alignContent="center"
+                            justifyContent="center"
+                        >
+                            {localTodos.length}
+                        </Box>
+                    ) : null}
+                </Box>
+                <Button
+                    variant="primary"
+                    fontSize="14px"
+                    _hover={{
+                        bg: "#0e0e52",
+                    }}
+                    isDisabled={!selected.length}
+                    onClick={removeToDos}
+                >
+                    Remove Todos
+                </Button>
             </Box>
             <Box
                 bg="gray.900"
@@ -223,24 +237,6 @@ const TodoList: React.FC<IProps> = ({ todos, removeFromToDos }) => {
                                                     <Box textAlign="right">{message.timestamp}</Box>
                                                 </Td>
                                             </Tr>
-                                            {message.id === selected[selected.length - 1] && (
-                                                <Tr w="100%" display="flex">
-                                                    <Td display="flex" flex="1 1 auto">
-                                                        <Button
-                                                            size="xs"
-                                                            variant="ghost"
-                                                            bg="red.500"
-                                                            _hover={{ background: "red.600" }}
-                                                            onClick={removeToDos}
-                                                        >
-                                                            Remove To Do
-                                                        </Button>
-                                                    </Td>
-                                                    <Td display="flex" flex="0 0 auto"></Td>
-                                                    <Td display="flex" flex="0 0 auto"></Td>
-                                                    <Td display="flex" flex="0 0 auto"></Td>
-                                                </Tr>
-                                            )}
                                         </>
                                     );
                                 })}


### PR DESCRIPTION
Moved "add to todos" and "remove from todos" buttons up into the header. Why?
* When multiple things are selected, the current setup is confusing UX. The "add to todo" button appears under only one, yet the button affects all of them. The button should affect all of them! And a place one level up in the layout hierarchy, such as the header is the right spot
* For drag'n'drop purposes, it's awkward to be dragging both the entry and its expansion. Do we truly want to drag both? Probably not. Managing the expanded rows complicates the implementation.


https://github.com/djowinz/toodle/assets/841124/b15e4c19-b2f7-42c6-91f5-1cd1fb99b521

